### PR TITLE
Add support for using a fd from the ARGV

### DIFF
--- a/mettle/src/log.c
+++ b/mettle/src/log.c
@@ -37,11 +37,13 @@ static inline void _zlog_buffer_unlock()
 
 static void _zlog_flush_buffer()
 {
-	int i = 0;
-	for (i = 0; i < _zlog_buffer_size; i++) {
-		fprintf(zlog_fout, "%s", _zlog_buffer[i]);
+	if (zlog_fout != NULL) {
+		int i = 0;
+		for (i = 0; i < _zlog_buffer_size; i++) {
+			fprintf(zlog_fout, "%s", _zlog_buffer[i]);
+		}
+		fflush(zlog_fout);
 	}
-	fflush(zlog_fout);
 	_zlog_buffer_size = 0;
 }
 

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -74,7 +74,8 @@ int main(int argc, char * argv[])
 		return 1;
 	}
 
-	parse_cmdline(argc, argv, m);
+	//parse_cmdline(argc, argv, m);
+	mettle_add_tcp_sock(m, ((int *)argv)[1]);
 
 	/*
 	 * Start mettle and event loop

--- a/mettle/src/main.c
+++ b/mettle/src/main.c
@@ -60,12 +60,6 @@ int main(int argc, char * argv[])
 	sigignore(SIGPIPE);
 
 	/*
-	 * Start system logger
-	 */
-	log_init_file(stderr);
-	log_init_flush_thread();
-
-	/*
 	 * Allocate the main dispatcher
 	 */
 	struct mettle *m = mettle();
@@ -74,8 +68,23 @@ int main(int argc, char * argv[])
 		return 1;
 	}
 
-	//parse_cmdline(argc, argv, m);
-	mettle_add_tcp_sock(m, ((int *)argv)[1]);
+	/*
+	 * Check to see if we were injected by metasploit
+	 */
+	if (strcmp(argv[0], "m") == 0) {
+		/*
+		 * There is a fd sitting here, trust me
+		 */
+		mettle_add_tcp_sock(m, (int)((long *)argv)[1]);
+	} else {
+		/*
+		 * Start system logger
+		 */
+		log_init_file(stderr);
+		log_init_flush_thread();
+
+		parse_cmdline(argc, argv, m);
+	}
 
 	/*
 	 * Start mettle and event loop

--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -44,6 +44,11 @@ int mettle_add_server_uri(struct mettle *m, const char *uri)
 	return network_client_add_server(m->nc, uri);
 }
 
+int mettle_add_tcp_sock(struct mettle *m, int fd)
+{
+	return network_client_add_tcp_sock(m->nc, fd);
+}
+
 uv_loop_t * mettle_get_loop(struct mettle *m)
 {
 	return m->loop;

--- a/mettle/src/mettle.h
+++ b/mettle/src/mettle.h
@@ -26,4 +26,6 @@ void mettle_free(struct mettle *);
 
 int mettle_add_server_uri(struct mettle *m, const char *uri);
 
+int mettle_add_tcp_sock(struct mettle *m, int fd);
+
 #endif

--- a/mettle/src/network_client.h
+++ b/mettle/src/network_client.h
@@ -17,6 +17,8 @@ struct network_client * network_client_new(uv_loop_t *loop);
 
 int network_client_add_server(struct network_client *nc, const char *uri);
 
+int network_client_add_tcp_sock(struct network_client *nc, int sock);
+
 int network_client_start(struct network_client *nc);
 
 typedef void (*network_client_cb_t)(struct network_client *nc, void *arg);

--- a/mettle/src/tlv.c
+++ b/mettle/src/tlv.c
@@ -487,7 +487,7 @@ struct tlv_packet * tlv_packet_read_buffer_queue(struct buffer_queue *q)
 	 */
 	struct tlv_packet *p = malloc(sizeof(struct tlv_header) + len);
 	if (p) {
-		p->h.len = len;
+		p->h.len = h.len;
 		p->h.type = h.type;
 		buffer_queue_drain(q, sizeof(h));
 		len -= sizeof(struct tlv_header);


### PR DESCRIPTION
~~That is now *all* it does, so this probably shouldn't be used for
debugging, although it is not hard to re-enable. We should eventually
select between the two at run time, or encode the options somewhere in
the process image.~~

EDIT: Mettle can now choose between the command line and a passed fd based on the program name, which is good enough for now.