### PR TITLE
Get reflected payloads working again

### DIFF
--- a/mettle/src/mettle.c
+++ b/mettle/src/mettle.c
@@ -148,7 +148,15 @@ struct mettle *mettle(void)
 		return NULL;
 	}
 
-	m->loop = ev_default_loop(EVFLAG_NOENV);
+	/*
+	 * TODO: let libev choose the backend instead of demanding select. On Linux
+	 * 2.6.22 we get the following with the epoll backend (compiled with much
+	 * more recent headers):
+	 *
+	 * (libev) epoll_wait: Bad file descriptor
+	 * Abort
+	 */
+	m->loop = ev_default_loop(EVFLAG_NOENV | EVBACKEND_SELECT);
 
 	ev_idle_init(&eio_idle_watcher, eio_idle_cb);
 	ev_async_init(&eio_async_watcher, eio_async_cb);

--- a/mettle/src/network_client.c
+++ b/mettle/src/network_client.c
@@ -517,9 +517,9 @@ int network_client_add_tcp_sock(struct network_client *nc, int sock)
 	if (nc->servers == NULL) {
 		return -1;
 	}
-	nc->num_servers++;
 
 	struct network_client_server *srv = &nc->servers[nc->num_servers];
+	nc->num_servers++;
 
 	char service[7];
 	struct sockaddr_storage addr;


### PR DESCRIPTION
Fix a segfault in the code that adds open file descriptors to the event
loop, and manually choose the select backend for libev as a workaround
for older kernels.

Needed for rapid7#17
